### PR TITLE
Fix the state machine

### DIFF
--- a/fpo.py
+++ b/fpo.py
@@ -1222,13 +1222,13 @@ def t_proxy_restore(overridden: Any, meta: TypeMeta):
         meta.apply_extensions(self, fp, _ON_RESTORE)
         _call(self, _ON_RESTORE, fp)
 
-        self._fp_state = FeatureState.Restored
+        self.__so_state__ = FeatureState.Restored
 
         meta.apply_extensions(self, fp, _ON_START)
         meta.ensure_properties(self, fp)
         _call(self, _ON_START, fp)
 
-        self._fp_state = FeatureState.Active
+        self.__so_state__ = FeatureState.Active
     return handler
 
 


### PR DESCRIPTION
The state was set to the wrong member `_fp_state`.

By the way, I think that `_so_state` would be a better name. Names starting and ending with `__` are ["reserved"](https://peps.python.org/pep-0008/#descriptive-naming-styles) in Python and the trailing underscores do not bring anything in my opinion. I can write a PR.

What does `SO` actually stands for?