### PR TITLE
Allow to set a property as string in proxies

### DIFF
--- a/fpo.py
+++ b/fpo.py
@@ -624,15 +624,19 @@ class Property(Generic[_PT]):
     # ──────────
     def update(self, obj: ObjectRef, value: _PT) -> None:
         """Set the value of the property in the remote object."""
-        if hasattr(obj, self.name):
-            if self.enum:
-                setattr(obj, self.name, str(value.value))
+        if not hasattr(obj, self.name):
+            return
+        if self.enum:
+            setattr(obj, self.name, str(value.value))
+            return
+        attr = getattr(obj, self.name)
+        if hasattr(attr, "Value"):
+            if isinstance(value, str):
+                attr.Value = App.Units.Quantity(value)
             else:
-                attr = getattr(obj, self.name)
-                if hasattr(attr, "Value"):
-                    attr.Value = value
-                else:
-                    setattr(obj, self.name, value)
+                attr.Value = value
+            return
+            setattr(obj, self.name, value)
 
     # ──────────
     def read(self, obj: ObjectRef) -> _PT:


### PR DESCRIPTION
Also reduce the indentation level by exiting early.

To test:
```python
@proxy()
class MyData:
    elements = PropertyInteger(default=3)
    thickness = PropertyLength(default=1)
    angle = PropertyAngle(default=30)
    source = PropertyLink()

    def on_create(self):
        self.angle = 90
        print(f'{self.angle=}')
        self.angle = '15 deg'
        print(f'{self.angle=}')
        self.angle = App.Units.Quantity('20 deg')
        print(f'{self.angle=}')
```
In `ex1_basic.py`.