### PR TITLE
Add `Proxy.is_active()`

### DIFF
--- a/fpo.py
+++ b/fpo.py
@@ -1394,6 +1394,7 @@ def proxy(  # noqa: ANN201
         t_dumps(meta)
         t_proxy_view_provider_name_override(meta)
         t_proxy_dirty(meta)
+        t_proxy_is_active(meta)
         return cls
 
     return transformer
@@ -1905,6 +1906,17 @@ def t_proxy_view_provider_name_override(_, meta: TypeMeta) -> GeneratedMethod:
 
         return getViewProviderName
     return None
+
+
+##$ ────────────────────────────────────────────────────────────────────────────
+@template(name="is_active", allow_override=True)
+def t_proxy_is_active(overridden: Any, meta: TypeMeta) -> GeneratedMethod:
+    if overridden:
+        return overridden
+
+    def is_active(self: Any) -> bool:
+        return getattr(self, '__so_state__', None) == FeatureState.Active
+    return is_active
 
 
 ##$ ┌───────────────────────────────────────────────────────────────────────────┐


### PR DESCRIPTION
I'm not sure whether this is really needed but I learned to triple-check attributes in FreeCAD objects when writing proxies. Anyway, this PR adds the `Proxy.is_active()` function to allow objects linking other proxied objects to check whether the linked objects are ready.

I hope I understood `fpo` and all the decorators well.