### PR TITLE
Add a safeguard against removing non-existing dialogs

### DIFF
--- a/fcui.py
+++ b/fcui.py
@@ -32,6 +32,7 @@ __min_freecad__ = "0.22"
 ##: [SECTION] Builtin Imports
 ##: ────────────────────────────────────────────────────────────────────────────
 
+from contextlib import suppress
 import json
 import re
 import sys
@@ -410,10 +411,9 @@ class PySignal:
 
     def disconnect(self, listener: Callable) -> None:
         """Remove listener."""
-        try:
+        with suppress(KeyError):
+            # OK if not found.
             self._listeners.remove(listener)
-        except KeyError:
-            pass  # Not found, Ok
 
     def emit(self, *args: tuple, **kwargs: KwArgs) -> None:
         """Trigger the signal."""
@@ -637,7 +637,8 @@ class Dialogs:
     @classmethod
     def destroy_dialog(cls, dialog: QWidget) -> None:
         """Remove dialog and prepare for gc."""
-        cls._list.remove(dialog)
+        with suppress(ValueError):
+            cls._list.remove(dialog)
         dialog.deleteLater()
 
     @classmethod


### PR DESCRIPTION
Also rewrites `try/except` to `contextlib.suppress` for clarity.

Maybe linked to this. The dialog from the Vars workbench pops up each time I switch from one document to another.

The error below appeared on
```
OS: Pop!_OS 22.04 LTS (wayland)
Architecture: x86_64
Version: 1.1.0dev.43071 (Git)
Build date: 2025/08/25 18:08:30
Build type: Release
Branch: main
Hash: d85613b498881c47485a7d930807673203086756
Python 3.10.12, Qt 5.15.3, Coin 4.0.0, Vtk 9.1.0, boost 1_74, Eigen3 3.4.0, PySide 5.15.2
shiboken 5.15.2, SMESH 7.7.1.0, xerces-c 3.2.3, IfcOpenShell 0.8.0, OCC 7.8.1
Locale: English/United States (en_US)
Navigation Style/Orbit Style/Rotation Mode: CAD/Turntable/Drag at cursor
Stylesheet/Theme/QtStyle: FreeCAD Dark.qss/FreeCAD Dark/Fusion
Logical DPI/Physical DPI/Pixel Ratio: 96/154.858/1
Installed mods: 
  * freecad.startup
  * freecad.cross 1.0.0
  * Curves 0.6.68
  * boltsfc 2022.11.5
  * kmr_workbench
  * manifest.json
  * freecad.robotcad 7.0.1 (Disabled)
  * Assembly2MuJoCo 0.2.0
  * toSketch 1.0.1
  * freecad.gears 1.3.0
  * CurvedShapes 1.0.13
  * Silk 0.2.0
  * fasteners 0.5.41
  * Freecad-Built-in-themes-beta 1.2.2
  * InventorLoader 1.5.1
  * FusedFilamentDesign 0.25.250
  * Render
  * Vars 0.0.2.beta4
  * OpenTheme 2025.5.20
  * Defeaturing 1.2.6
  * RobotDescriptor
  * sheetmetal 0.7.24
  * parametric_defeaturing
  * SvgWorkbench 1.0.0.dev6
  * FreeCAD-AI-Toolbar
  * MeshRemodel 1.10.38
  * MnesarcoUtils 0.2.16
```

```
11:18:14  Traceback (most recent call last):
11:18:14    File "/home/gael/.local/share/FreeCAD/Mod/Vars/freecad/vars/vendor/fcapi/fcui.py", line 635, in <lambda>
11:18:14      dialog.closeEvent = lambda _e: cls.destroy_dialog(dialog)
11:18:14    File "/home/gael/.local/share/FreeCAD/Mod/Vars/freecad/vars/vendor/fcapi/fcui.py", line 640, in destroy_dialog
11:18:14      cls._list.remove(dialog)
11:18:14  ValueError: list.remove(x): x not in list
```